### PR TITLE
Update documentation for solver module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Current features include:
 
 - Core Modules
   - Sparse eigenvalue computations for stability and adjoint problems *(planned)*
-  - Base flow construction and diagnostics *(planned)*
+  - Base flow construction via a steady Navier–Stokes solver
   - Automatic differentiation support *(planned)*
 
 - Infrastructure
@@ -46,16 +46,19 @@ Finite Element Method backend that assembles the linearized Navier–Stokes oper
 
 - Modular structure for building velocity-pressure function spaces.
 - Handles boundary condition enforcement for Dirichlet, Neumann, and Robin types.
+- Periodic boundary conditions via DOF pairing.
 - Exposes PETSc matrices for solver consumption.
 
-### Solver 
+### Solver
 
 Linear solver module that will support:
 
-- Base flow computation *(planned)*
+- Steady base flow computation
 - Eigenvalue solvers for modal stability analysis (via SLEPc)
 - Preconditioners for large sparse matrices
 - Fully decoupled from FEM to allow extensibility
+
+See [Solver documentation](doc/models/solver.md) for details.
 
 ### Visualizer *(Planned)*
 

--- a/doc/models/_index.md
+++ b/doc/models/_index.md
@@ -2,6 +2,7 @@
 
 - [Meshing](meshing.md): Mesh generation, import/export, CFD benchmark geometries.
 - [FEM](fem.md): Function spaces, boundary conditions, matrix assembly.
+- [Solver](solver.md): Base flow and eigenvalue solvers.
 - ...
 
 ---

--- a/doc/models/fem-operators.md
+++ b/doc/models/fem-operators.md
@@ -7,6 +7,9 @@
 Linear stability analysis of fluid flows requires linearizing the Navier-Stokes equations around a given base flow.
 This module provides tools to assemble the discrete matrices for this linearized system.
 
+Base flows can be computed with the `SteadyNavierStokesAssembler` described in
+the [Steady Base Flow Solver](fem.md#steady-base-flow-solver) section.
+
 The module supports both time-stepping simulations and eigenanalysis for stabilities, and it provides PETSc features for parallel assembly, block matrix storage and preconditioning.
 
 ## Variational Forms for Linearized Navier-Stokes

--- a/doc/models/fem.md
+++ b/doc/models/fem.md
@@ -59,14 +59,22 @@ It is built on top of FEniCSx and supports modular, extensible finite element fo
 | `spaces.py`        | Function space definitions for velocity and pressure                |
 | `bcs.py`           | Dirichlet, Neumann, and Robin boundary condition specification      |
 | `utils.py`         | Shared helpers and enums                                            |
-| `operators.py`     | Weak form assembly of the Navier–Stokes operators                   |
+| `operators.py`     | Linearized and steady Navier--Stokes assemblers |
 | `plot.py`          | Utils for matrix (sparsity) visualization                           |
 
 ## Submodules Index
 
 - [Function spaces](fem-spaces.md)
 - [Boundary conditions](fem-bcs.md)
-- ...
+- [Linearized operators](fem-operators.md)
+- [Steady base flow solver](#steady-base-flow-solver)
+
+## Steady Base Flow Solver
+
+`SteadyNavierStokesAssembler` implements a Newton iteration for the steady
+incompressible Navier–Stokes equations. It constructs the residual and Jacobian
+forms and exposes a `solve()` method that returns the converged velocity and
+pressure fields.
 
 ## Future Extensions
 

--- a/doc/models/solver.md
+++ b/doc/models/solver.md
@@ -1,0 +1,55 @@
+# LSA-FW Solver Module
+
+> [Back to index](_index.md)
+
+---
+
+## Overview
+
+The `Solver` package provides tools to compute base flows and to solve
+eigenvalue problems arising in stability analysis.  It builds on PETSc
+and SLEPc through thin wrapper classes that expose a user friendly API
+without hiding the underlying functionality.
+
+At the moment the focus is on the generalized eigenvalue problem
+$A x = \lambda M x$, which is used to compute the global modes of a
+linearized Navier–Stokes operator.  Additional utilities include
+plotting helpers for visualising eigenvectors.
+
+## Eigensolver API
+
+The high level interface is the `EigenSolver` class which accepts an
+`EigensolverConfig` dataclass.  The configuration collects the number of
+eigenpairs, tolerance and problem type.  Internally the solver delegates
+to `iEpsSolver`, a lightweight wrapper around `slepc4py.EPS`.
+
+```python
+from Solver.eigen import EigenSolver, EigensolverConfig, iEpsProblemType
+
+cfg = EigensolverConfig(
+    num_eig=6,
+    problem_type=iEpsProblemType.GHEP,
+    atol=1e-8,
+    max_it=500,
+)
+es = EigenSolver(cfg, A, M)
+values_and_vectors = es.solve()
+```
+
+The returned list contains `(eigenvalue, eigenvector)` tuples.  The
+`iEpsSolver` object can be accessed through `es.solver` to customise
+spectral transforms, preconditioners or target shifts.
+
+## Plotting Utilities
+
+`Solver.plot` provides a `plot_eigenvector` function that renders a
+solution field using PyVista.  It takes a `Mesher` instance, the finite
+element spaces and the eigenvector to plot.  Results can be displayed
+interactively or saved to disk as screenshots.
+
+## Future Work
+
+Planned extensions include iterative Newton solvers for the steady base
+flow computation and time-stepping capabilities for transient
+simulations.
+


### PR DESCRIPTION
## Summary
- link solver docs from README and models index
- document generalized eigenvalue solver
- clarify periodic boundary example and newline fix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dolfinx')*

------
https://chatgpt.com/codex/tasks/task_e_68468e4d62448323ac00a058fa0f9bd5