### PR TITLE
Apply log_global across modules

### DIFF
--- a/FEM/cli.py
+++ b/FEM/cli.py
@@ -30,7 +30,7 @@ from rich.console import Console
 import dolfinx.fem as dfem
 
 from config import load_bc_config
-from lib.loggingutils import setup_logging
+from lib.loggingutils import setup_logging, log_global
 
 from Meshing import Mesher, Shape
 
@@ -56,7 +56,9 @@ def _import_mesh(file_path: Path) -> Mesher:
             raise ValueError(f"Meshes of type '{file_path.suffix}' not supported.")
 
     mesher = Mesher.from_file(file_path, shape)
-    logger.info(
+    log_global(
+        logger,
+        logging.INFO,
         "Mesh imported with %d cells",
         mesher.mesh.topology.index_map(mesher.mesh.topology.dim).size_local,
     )
@@ -86,11 +88,11 @@ def _get_baseflow(
             raise ValueError(
                 "If no path to a disk-saved baseflow is given, enough data to compute it must be provided."
             )
-        logger.info("No base flow file provided; computing it from scratch.")
+        log_global(logger, logging.INFO, "No base flow file provided; computing it from scratch.")
         baseflow_solver = BaseFlowSolver(spaces, bcs=bcs)
         u_base = baseflow_solver.solve(re=re)
     else:
-        logger.info("Loading base flow from '%s'", base_flow_path)
+        log_global(logger, logging.INFO, "Loading base flow from '%s'", base_flow_path)
         u_base = load_baseflow(base_flow_path, spaces)
     if show_plot:
         plot_mixed_function(u_base, scale=0.025, title="Base flow")
@@ -98,7 +100,7 @@ def _get_baseflow(
 
 
 def _export_matrices(A: iPETScMatrix, M: iPETScMatrix, output_path: Path) -> None:
-    logger.info(f"Output will be saved to: {output_path}")
+    log_global(logger, logging.INFO, f"Output will be saved to: {output_path}")
     output_path.mkdir(parents=True, exist_ok=True)
     A.export(output_path / "A.petsc")
     M.export(output_path / "M.petsc")
@@ -117,7 +119,7 @@ def assemble_fem(args: argparse.Namespace) -> None:
     _export_matrices(A, M, args.output_path / "matrices")
 
     if args.plot:
-        logger.info(f"Plots will be saved to: {args.output_path}/plots")
+        log_global(logger, logging.INFO, f"Plots will be saved to: {args.output_path}/plots")
         A_block = assembler.extract_subblocks(A)
         M_block = assembler.extract_subblocks(M)
         spy(A_block, args.output_path / "plots" / "A.png")
@@ -182,7 +184,7 @@ def main():
         try:
             assemble_fem(args)
         except Exception as e:
-            logger.exception("Error during CLI execution: %s", e)
+            log_global(logger, logging.ERROR, "Error during CLI execution: %s", e)
             raise SystemExit(1)
     else:
         console.print("[red]Unknown command. Use --help for usage info.[/red]")

--- a/FEM/operators.py
+++ b/FEM/operators.py
@@ -42,6 +42,7 @@ from .utils import iPETScMatrix, iPETScVector, iPETScNullSpace, iPETScBlockMatri
 from .spaces import FunctionSpaces
 from lib.cache import CacheStore
 from .bcs import BoundaryConditions, apply_periodic_constraints
+from lib.loggingutils import log_global
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +247,7 @@ class StationaryNavierStokesAssembler(BaseAssembler):
 
         self._residual, self._jacobian = self._build_forms()
 
-        logger.info("Stationary Navier Stokes assembler has been initialized.")
+        log_global(logger, logging.INFO, "Stationary Navier Stokes assembler has been initialized.")
 
     @property
     def residual(self) -> dfem.Form:

--- a/FEM/spaces.py
+++ b/FEM/spaces.py
@@ -17,6 +17,7 @@ import dolfinx.mesh as dmesh
 from basix.ufl import element, enriched_element, mixed_element
 
 from Meshing.utils import iCellType
+from lib.loggingutils import log_global
 
 from .utils import iElementFamily
 
@@ -150,8 +151,10 @@ def define_spaces(
             pressure = functionspace(mesh, p1_p)
 
         case FunctionSpaceType.SIMPLE:
-            logger.warning(
-                "Using equal-order P1-P1 function spaces. This may lead to instability."
+            log_global(
+                logger,
+                logging.WARNING,
+                "Using equal-order P1-P1 function spaces. This may lead to instability.",
             )
 
             p1_v = element(

--- a/FEM/utils.py
+++ b/FEM/utils.py
@@ -16,6 +16,7 @@ from basix import ElementFamily as DolfinxElementFamily
 from dolfinx.mesh import Mesh, MeshTags
 from ufl import Measure  # type: ignore[import-untyped]
 from petsc4py import PETSc
+from lib.loggingutils import log_global
 
 logger = logging.getLogger(__name__)
 
@@ -357,9 +358,11 @@ class iPETScMatrix:
     def nonzero_entries(self) -> int:
         """Return the number of non-zero entries in the matrix."""
         if "dense" in self.type:
-            logger.warning(
+            log_global(
+                logger,
+                logging.WARNING,
                 "The current matrix is dense, so all the entries are memory-allocated. "
-                "Then, the value returned by this property might not be useful."
+                "Then, the value returned by this property might not be useful.",
             )
 
         if "nest" in self.type:
@@ -611,7 +614,7 @@ class iPETScVector:
         try:
             vec.assemble()
         except Exception:
-            logger.warning("PETSc vector could not be assembled upon initialization.")
+            log_global(logger, logging.WARNING, "PETSc vector could not be assembled upon initialization.")
         self._vec = vec
 
     @classmethod
@@ -698,9 +701,11 @@ class iPETScVector:
         if not isinstance(other, iPETScVector):
             return NotImplemented
 
-        logger.warning(
+        log_global(
+            logger,
+            logging.WARNING,
             "Vector outer product creates a dense matrix; if you need a sparse result, "
-            "override __matmul__ for sparse vectors."
+            "override __matmul__ for sparse vectors.",
         )
 
         A = PETSc.Mat().createDense([self.size, other.size], comm=self.comm)
@@ -847,9 +852,11 @@ class iComplexPETScVector:
             # In a complex PETSc build, ignore any provided imaginary part
             self._imag = None
             if imag is not None:
-                logger.warning(
+                log_global(
+                    logger,
+                    logging.WARNING,
                     "PETSc is built in a complex-floating point configuration. "
-                    "Please use `iPETScVector`."
+                    "Please use `iPETScVector`.",
                 )
         else:
             # In a real PETSc build, accept or lazy-allocate imag
@@ -1279,7 +1286,7 @@ class iPETScNullSpace:
         try:
             self._raw.remove(vec.raw)
         except Exception as e:
-            logger.exception(f"NullSpace.remove failed: {e}")
+            log_global(logger, logging.ERROR, f"NullSpace.remove failed: {e}")
             raise
 
     def attach_to(self, mat: iPETScMatrix) -> None:
@@ -1297,7 +1304,7 @@ class iPETScNullSpace:
         try:
             self._raw.destroy()
         except Exception as e:
-            logger.warning(f"NullSpace.destroy failed: {e}")
+            log_global(logger, logging.WARNING, f"NullSpace.destroy failed: {e}")
 
 
 class iPETScBlockMatrix:

--- a/Meshing/cli.py
+++ b/Meshing/cli.py
@@ -34,7 +34,7 @@ from rich.console import Console
 
 from mpi4py import MPI
 
-from lib.loggingutils import setup_logging
+from lib.loggingutils import setup_logging, log_global
 from config import (
     load_cylinder_flow_config,
     load_step_flow_config,
@@ -62,7 +62,7 @@ def _generate(args: argparse.Namespace) -> None:
             tuple(args.domain[len(resolution) :]),
         )
 
-    logger.info("Generating mesh: %s, resolution=%s", args.shape, resolution)
+    log_global(logger, logging.INFO, "Generating mesh: %s, resolution=%s", args.shape, resolution)
     mesher = Mesher(
         shape=args.shape,
         n=resolution,
@@ -71,7 +71,9 @@ def _generate(args: argparse.Namespace) -> None:
     )
     mesher.generate()
 
-    logger.info(
+    log_global(
+        logger,
+        logging.INFO,
         "Mesh generated with %d cells",
         mesher.mesh.topology.index_map(mesher.mesh.topology.dim).size_local,
     )
@@ -82,9 +84,9 @@ def _generate(args: argparse.Namespace) -> None:
 
     if args.export:
         fmt = args.format or Format.XDMF
-        logger.info("Exporting mesh to: %s as %s", args.export, fmt)
+        log_global(logger, logging.INFO, "Exporting mesh to: %s as %s", args.export, fmt)
         mesher.export(args.export, fmt)
-        logger.info("Export complete.")
+        log_global(logger, logging.INFO, "Export complete.")
 
     if args.plot:
         plot_mesh(mesher.mesh, tags=mesher.facet_tags, show_edges=True)
@@ -92,19 +94,21 @@ def _generate(args: argparse.Namespace) -> None:
 
 def _import(args: argparse.Namespace) -> None:
     """Import a mesh from XDMF or MSH using Mesher.from_file."""
-    logger.info("Importing mesh: %s (%s)", args.path, args.import_type)
+    log_global(logger, logging.INFO, "Importing mesh: %s (%s)", args.path, args.import_type)
     mesher = Mesher.from_file(path=args.path, shape=args.import_type, gdim=args.gdim)
 
-    logger.info(
+    log_global(
+        logger,
+        logging.INFO,
         "Mesh imported with %d cells",
         mesher.mesh.topology.index_map(mesher.mesh.topology.dim).size_local,
     )
 
     if args.export:
         fmt = args.format or Format.XDMF
-        logger.info("Exporting mesh to: %s as %s", args.export, fmt)
+        log_global(logger, logging.INFO, "Exporting mesh to: %s as %s", args.export, fmt)
         mesher.export(args.export, fmt)
-        logger.info("Export complete.")
+        log_global(logger, logging.INFO, "Export complete.")
 
     if args.plot:
         plot_mesh(mesher.mesh)
@@ -112,7 +116,7 @@ def _import(args: argparse.Namespace) -> None:
 
 def _benchmark(args: argparse.Namespace) -> None:
     """Generate a predefined CFD benchmark geometry via Mesher.from_geometry."""
-    logger.info("Generating benchmark geometry: %s", args.geometry)
+    log_global(logger, logging.INFO, "Generating benchmark geometry: %s", args.geometry)
 
     match args.geometry:
         case Geometry.CYLINDER_FLOW:
@@ -124,7 +128,9 @@ def _benchmark(args: argparse.Namespace) -> None:
 
     mesher = Mesher.from_geometry(args.geometry, cfg, comm=MPI.COMM_WORLD)
     mesh = mesher.mesh
-    logger.info(
+    log_global(
+        logger,
+        logging.INFO,
         "Mesh generated with %d cells",
         mesh.topology.index_map(mesh.topology.dim).size_local,
     )
@@ -135,9 +141,9 @@ def _benchmark(args: argparse.Namespace) -> None:
 
     if args.export:
         fmt = args.format or Format.XDMF
-        logger.info("Exporting mesh to: %s as %s", args.export, fmt)
+        log_global(logger, logging.INFO, "Exporting mesh to: %s as %s", args.export, fmt)
         mesher.export(args.export, fmt)
-        logger.info("Export complete.")
+        log_global(logger, logging.INFO, "Export complete.")
 
     if args.plot:
         plot_mesh(mesher.mesh, tags=mesher.facet_tags, show_edges=True)
@@ -225,5 +231,5 @@ def main():
     try:
         args.func(args)
     except Exception as e:
-        logger.exception("Error during CLI execution: %s", e)
+        log_global(logger, logging.ERROR, "Error during CLI execution: %s", e)
         raise SystemExit(1)

--- a/Meshing/core.py
+++ b/Meshing/core.py
@@ -14,6 +14,7 @@ from dolfinx.mesh import MeshTags, compute_midpoints, locate_entities_boundary, 
 
 from .utils import Format, Shape, iCellType, Geometry
 from lib.cache import CacheStore
+from lib.loggingutils import log_global
 from .geometries import get_geometry, GeometryConfig
 
 logger = logging.getLogger(__name__)
@@ -239,12 +240,12 @@ class Mesher:
                     if self._facet_tags is not None:
                         file.write_meshtags(self._facet_tags, self.mesh.geometry)
                     else:
-                        logger.warning("No facet tags to export.")
+                        log_global(logger, logging.WARNING, "No facet tags to export.")
 
                     if self._cell_tags is not None:
                         file.write_meshtags(self._cell_tags, self.mesh.geometry)
                     else:
-                        logger.warning("No cell tags to export.")
+                        log_global(logger, logging.WARNING, "No cell tags to export.")
 
             case Format.VTK:
                 with dio.VTKFile(comm, str(path), "w") as vtk_file:
@@ -327,12 +328,12 @@ class Mesher:
             try:
                 self._facet_tags = xdmf.read_meshtags(mesh, name="facet_tags")
             except Exception:
-                logger.warning("No facet tags found in XDMF.")
+                log_global(logger, logging.WARNING, "No facet tags found in XDMF.")
 
             try:
                 self._cell_tags = xdmf.read_meshtags(mesh, name="cell_tags")
             except Exception:
-                logger.warning("No cell tags found in XDMF.")
+                log_global(logger, logging.WARNING, "No cell tags found in XDMF.")
 
         return mesh
 

--- a/Meshing/plot.py
+++ b/Meshing/plot.py
@@ -18,6 +18,7 @@ from mpi4py import MPI
 from dolfinx.mesh import Mesh, MeshTags
 from dolfinx.plot import vtk_mesh
 import dolfinx.io as dio
+from lib.loggingutils import log_global
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +62,10 @@ def plot_mesh(
             return
 
     if mode is not PlotMode.INTERACTIVE and not screenshot_path:
-        logger.warning(
-            "Non-interactive mode with no export: nothing will be displayed or saved."
+        log_global(
+            logger,
+            logging.WARNING,
+            "Non-interactive mode with no export: nothing will be displayed or saved.",
         )
         return
 
@@ -74,8 +77,10 @@ def plot_mesh(
     if background != "transparent":
         plotter.set_background(background)
     elif not off_screen:
-        logger.warning(
-            "Transparent background only supported off-screen; using default background."
+        log_global(
+            logger,
+            logging.WARNING,
+            "Transparent background only supported off-screen; using default background.",
         )
 
     if tags_to_plot is None:
@@ -87,13 +92,13 @@ def plot_mesh(
         elif tags_to_plot.dim == dim - 1:
             _add_facet_tags(plotter, mesh_to_plot, grid, tags_to_plot, show_edges)
         else:
-            logger.warning("MeshTags dimension %d not supported.", tags.dim)
+            log_global(logger, logging.WARNING, "MeshTags dimension %d not supported.", tags.dim)
 
     if screenshot_path:
         ext = screenshot_path.suffix.lower()
         if ext == ".svg":
             plotter.save_graphic(str(screenshot_path))
-            logger.info("Exported mesh to SVG: %s", screenshot_path)
+            log_global(logger, logging.INFO, "Exported mesh to SVG: %s", screenshot_path)
         elif ext == ".png":
             plotter.screenshot(
                 str(screenshot_path),
@@ -168,7 +173,7 @@ def _add_facet_tags(
                 lines.extend([2, *vids.tolist()])
                 vals.append(int(t))
         if not vals:
-            logger.warning("No 2D facets tagged, skipping facet plot.")
+            log_global(logger, logging.WARNING, "No 2D facets tagged, skipping facet plot.")
             return
         cells = np.array(lines, np.int64)
         types = np.full(len(vals), pv.CellType.LINE, np.uint8)
@@ -205,7 +210,7 @@ def _add_facet_tags(
                 faces.extend([len(local), *local])
                 vals.append(int(t))
         if not vals:
-            logger.warning("No 3D facets tagged, skipping facet plot.")
+            log_global(logger, logging.WARNING, "No 3D facets tagged, skipping facet plot.")
             return
         poly = pv.PolyData(coords, np.array(faces, np.int64))
         poly.cell_data["facet tags"] = np.array(vals, np.int32)
@@ -224,7 +229,7 @@ def _add_facet_tags(
             },
         )
     else:
-        logger.warning("Mesh dimension %d not supported for facets.", dim)
+        log_global(logger, logging.WARNING, "Mesh dimension %d not supported for facets.", dim)
 
 
 def _gather_mesh_from_ranks(

--- a/Solver/cli.py
+++ b/Solver/cli.py
@@ -36,7 +36,7 @@ from config import (
     load_facet_config,
     load_bc_config,
 )
-from lib.loggingutils import setup_logging
+from lib.loggingutils import setup_logging, log_global
 
 from Meshing import Mesher, Geometry
 from FEM.spaces import define_spaces, FunctionSpaceType
@@ -134,7 +134,7 @@ def main() -> None:
     try:
         args.func(args)
     except Exception as exc:
-        logger.exception("Error during CLI execution: %s", exc)
+        log_global(logger, logging.ERROR, "Error during CLI execution: %s", exc)
         raise SystemExit(1)
 
 

--- a/Solver/eigen.py
+++ b/Solver/eigen.py
@@ -31,6 +31,7 @@ import time
 from dataclasses import dataclass
 
 from FEM.utils import iPETScMatrix, iComplexPETScVector
+from lib.loggingutils import log_global
 
 from .utils import iEpsProblemType, iEpsSolver
 
@@ -77,9 +78,10 @@ class EigenSolver:
                 )
         if cfg.problem_type in _HERMITIAN_TYPES:
             if not A.is_numerically_hermitian():
-                logger.warning(
-                    f"Problem type '{cfg.problem_type.name}' assumes Hermitian A,"
-                    " but A is not (numerically) Hermitian."
+                log_global(
+                    logger,
+                    logging.WARNING,
+                    f"Problem type '{cfg.problem_type.name}' assumes Hermitian A," " but A is not (numerically) Hermitian.",
                 )
             if (
                 M is not None
@@ -87,9 +89,10 @@ class EigenSolver:
                 and not M.is_numerically_hermitian()
             ):
 
-                logger.warning(
-                    f"Problem type '{cfg.problem_type.name}' assumes Hermitian M,"
-                    " but M is not (numerically) Hermitian."
+                log_global(
+                    logger,
+                    logging.WARNING,
+                    f"Problem type '{cfg.problem_type.name}' assumes Hermitian M," " but M is not (numerically) Hermitian.",
                 )
 
         self._cfg = cfg
@@ -111,10 +114,12 @@ class EigenSolver:
 
     def solve(self) -> list[tuple[float | complex, iComplexPETScVector]]:
         """Run the solver and return eigenpairs."""
-        logger.info(
+        log_global(
+            logger,
+            logging.INFO,
             f"Starting eigenvalue solve: type={self._cfg.problem_type.name}, "
             f"nev={self._cfg.num_eig}, "
-            f"tol={self._cfg.atol}, max_it={self._cfg.max_it}"
+            f"tol={self._cfg.atol}, max_it={self._cfg.max_it}",
         )
 
         t0 = time.time()
@@ -128,11 +133,13 @@ class EigenSolver:
         except Exception:
             its = None
 
-        logger.info(
+        log_global(
+            logger,
+            logging.INFO,
             f"Solve completed in {elapsed:.2f} s; converged {nconv} eigenpairs"
-            + (f"; iterations={its}" if its is not None else "")
+            + (f"; iterations={its}" if its is not None else ""),
         )
 
         pairs = list(self._solver.get_all_eigenpairs_up_to(self._cfg.num_eig))
-        logger.info(f"Retrieved {len(pairs)} eigenpairs")
+        log_global(logger, logging.INFO, f"Retrieved {len(pairs)} eigenpairs")
         return pairs

--- a/Solver/linear.py
+++ b/Solver/linear.py
@@ -168,7 +168,7 @@ class LinearSolver:
         key: int | str | None,
         restart: int | None = None,
     ) -> dfem.Function:
-        logger.info(f"{ksp_type.name} solve started.")
+        log_global(logger, logging.INFO, f"{ksp_type.name} solve started.")
         cache_key = key or f"{ksp_type.name.lower()}_{id(self)}"
 
         # Assemble and cache system matrix, RHS, and solution vector


### PR DESCRIPTION
## Summary
- use `log_global` for warnings and infos in CLI tools and utilities
- ensure messages are only emitted on rank 0 across modules
- switch remaining `logger.info` in `LinearSolver` to `log_global`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff5c805ac8323be987e2fa2f21375